### PR TITLE
fix: jump to current day when opening timetable

### DIFF
--- a/lib/controllers/timetable_controller.dart
+++ b/lib/controllers/timetable_controller.dart
@@ -95,8 +95,7 @@ class TimetableController extends ChangeNotifier {
     if (!_differentDate(week.start, Week.fromId(0).start)) week.start = TimetableController.getSchoolYearStart();
 
     currentWeek = week;
-    // when currentWeekId has no value, set prevId to id
-    previousWeekId = currentWeekId == -1 ? id : currentWeekId;
+    previousWeekId = currentWeekId;
     currentWeekId = id;
     return false;
   }


### PR DESCRIPTION
see https://github.com/filc/mobile/blob/master/lib/pages/timetable/timetable_page.dart#L73